### PR TITLE
docker: Clean-up Docker support for build-latest-p2pdma-kernel

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,0 @@
-linux-*
-temp
-tmp
-.*

--- a/README.md
+++ b/README.md
@@ -61,6 +61,27 @@ point to the latest and greatest p2pdma kernel. Run this to generate a
 p2pdma kernel unless you know what you are doing and want to use
 build-kernel-debrpm. Only supports x86_64 right now.
 
+## docker
+
+A Dockerfile exists that can generate the enviromnent needed to run
+```build-latest-p2pdma-kernel```. This can make the generation of the
+.deb for this kernel simpler for some users. To generate the kernel
+Debian packages this way proceed as follows from the top-level folder
+of this repo.
+```
+cd docker
+docker build -t kernel-tools:latest .
+```
+once the image has run to completion you can obtain the tarball via
+the following (from either the docker folder or the top-level folder
+for this repo).
+```
+docker create --name kernel-tools kernel-tools:latest
+docker cp kernel-tools:/kernel/build-kernel-deb.docker.tar.gz .
+```
+You can then install the .deb using the same approach as a native
+build using build-latest-p2pdma-kernel.
+
 ## arm-tools
 
 The ```arm-tools``` sub-folder contains a few useful tools for

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,15 +1,15 @@
 # A Dockerfile that generates the latest p2pdma .deb from inside a
 # docker container. Since we do this inside docker we have a lot of
 # control on which distro and tooling we use. Useful for testing and
-# for when the distro you use does not support
-# build-latest-p2pdma-kernel.
+# for when the distro you use does not support the
+# build-latest-p2pdma-kernel script.
 #
 # Once this container build runs to completion you can use the docker
 # copy command (docker cp) to copy the .deb files to the host and use
 # dpkg -i to do the package install on your system.
 
   # Change this to your preferred distro.
-FROM ubuntu:19.04
+FROM ubuntu:18.04
 
   # Note this list may change depending on the distro chosen.
 RUN apt-get update && apt-get install -y \
@@ -21,7 +21,8 @@ RUN apt-get update && apt-get install -y \
     bc \
     kmod \
     cpio \
-    libssl-dev
+    libssl-dev \
+    rsync
 
   # Note you may want to edit this depending on what you want to build
   # and the capabilities of your system. 
@@ -29,3 +30,4 @@ RUN apt-get update && apt-get install -y \
 RUN git clone https://github.com/sbates130272/kernel-tools.git kernel
 WORKDIR kernel
 RUN THREADS=8 ./build-latest-p2pdma-kernel
+RUN cp build-kernel-deb.*.tar.gz build-kernel-deb.docker.tar.gz


### PR DESCRIPTION
Move the Dockerfile into a subfolder (which removes the need for a
.dockerignore file). Also update the README.md and make some fixes to
the Dockerfile.