### PR TITLE
obuild-kernel-debrpm: Added sorting to the patch find

### DIFF
--- a/build-kernel-debrpm
+++ b/build-kernel-debrpm
@@ -80,7 +80,7 @@ cd $WORKDIR/kernel
   # all the *.patch files in that folder.
 
 function patchdir() {
-    for file in $(find $1 -name "*.patch") ; do
+    for file in $(find $1 -name "*.patch" | sort -n) ; do
 	echo Applying patch-file $file.
 	cat $file | patch -p1 -l
     done


### PR DESCRIPTION
Find is not guaranteed to produce results in alphabetical order.
Therefore, we'll pipe this to sort to sort it in ascending order.

Fixes issue #9