### PR TITLE
docker: Update Dockerfile and improve instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,12 @@ A Dockerfile exists that can generate the enviromnent needed to run
 ```build-latest-p2pdma-kernel```. This can make the generation of the
 .deb for this kernel simpler for some users. To generate the kernel
 Debian packages this way proceed as follows from the top-level folder
-of this repo.
+of this repo. Note that since we always pull from the HEAD of the
+repository we need to run docker with ```-no-cache```. This slows down
+the build time but avoids incorrect builds.
 ```
 cd docker
-docker build -t kernel-tools:latest .
+docker build --no-cache -t kernel-tools:latest .
 ```
 once the image has run to completion you can obtain the tarball via
 the following (from either the docker folder or the top-level folder
@@ -105,6 +107,7 @@ for this repo).
 ```
 docker create --name kernel-tools kernel-tools:latest
 docker cp kernel-tools:/kernel/build-kernel-deb.docker.tar.gz .
+docker rm kernel-tools
 ```
 You can then install the .deb using the same approach as a native
 build using build-latest-p2pdma-kernel.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,8 @@
 #
 # Once this container build runs to completion you can use the docker
 # copy command (docker cp) to copy the .deb files to the host and use
-# dpkg -i to do the package install on your system.
+# dpkg -i to do the package install on your system. See the top-level
+# README.md for more information.
 
   # Change this to your preferred distro.
 FROM ubuntu:18.04
@@ -29,5 +30,5 @@ RUN apt-get update && apt-get install -y \
  
 RUN git clone https://github.com/sbates130272/kernel-tools.git kernel
 WORKDIR kernel
-RUN THREADS=8 ./build-latest-p2pdma-kernel
+RUN ./build-latest-p2pdma-kernel
 RUN cp build-kernel-deb.*.tar.gz build-kernel-deb.docker.tar.gz


### PR DESCRIPTION
Improve the instructions and the Dockerfile for docker generation of
the build-latest-p2pdma-kernel.