### PR TITLE
docker/Dockerfile: Fix REMOTE

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,5 +30,6 @@ RUN apt-get update && apt-get install -y \
  
 RUN git clone https://github.com/sbates130272/kernel-tools.git kernel
 WORKDIR kernel
+ENV REMOTE http://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git
 RUN ./build-latest-p2pdma-kernel
 RUN cp build-kernel-deb.*.tar.gz build-kernel-deb.docker.tar.gz


### PR DESCRIPTION
The REMOTE environment variable needs to be set to run the correct
build scripts for the p2pdma kernel. Update the Dockerfile to set this
variable.