### PR TITLE
src folder: Update README.md to discuss single source folder

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -83,6 +83,7 @@ sbates
 scm
 sig
 sr
+src
 standlone
 sudo
 symvers

--- a/README.md
+++ b/README.md
@@ -7,9 +7,7 @@ This repo contains a few scripts I find useful for kernel hacking.
 I normally have a top-level folder called kernel which I place this
 repo into. I then have a number of sub-folders:
 
-+ **```linux-<arch>```**: The [Linux Kernel][1] tree with different
-directories for each architecture I am working on (e.g. arm64, riscv,
-x86 etc).
++ **```src```**: The [Linux Kernel][1] tree.
 
 + **```useful-configs```**: A folder for some good kernel configs. For
 example this includes a really small (but valid) config, a QEMU


### PR DESCRIPTION
The new practice for kernel-tools is to put said kernel in the src folder and not in a ARCH specific folder. So we fix that.

Fixes #23.