### PR TITLE
docker: Update the docker-based generation method and add to CI

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -1,0 +1,19 @@
+name: docker-test
+
+on:
+  pull_request:
+    branches: [ main ]
+    path:
+      - ./scripts/build-latest-p2pdma-kernel
+      - ./docker/Dockerfile
+
+jobs:
+  docker-test:
+    name: docker-test
+    runs-on: ubuntu-latest
+    steps:
+    - name: check out code using action/checkout
+      uses: actions/checkout@v4.2.2
+    - name: build package via the Dockerfile method
+      run: docker build .
+      working-directory: docker

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,7 @@
 # README.md for more information.
 
   # Change this to your preferred distro.
-FROM ubuntu:18.04
+FROM ubuntu:24.04
 
   # Note this list may change depending on the distro chosen.
 RUN apt-get update && apt-get install -y \
@@ -26,10 +26,10 @@ RUN apt-get update && apt-get install -y \
     rsync
 
   # Note you may want to edit this depending on what you want to build
-  # and the capabilities of your system. 
- 
+  # and the capabilities of your system.
+
 RUN git clone https://github.com/sbates130272/kernel-tools.git kernel
 WORKDIR kernel
 ENV REMOTE http://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git
-RUN ./build-latest-p2pdma-kernel
+RUN ./scripts/build-latest-p2pdma-kernel
 RUN cp build-kernel-deb.*.tar.gz build-kernel-deb.docker.tar.gz


### PR DESCRIPTION
The docker method of generating the Linux kernel was out of date so we fixed that and added it to our CI workflows at the same time.

Fixes #29.