### PR TITLE
init-update: Add a remote to the Linux Kernel Library repo

### DIFF
--- a/scripts/init-update
+++ b/scripts/init-update
@@ -21,6 +21,7 @@ GIT_REMOTE_LINUS=https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.
 GIT_REMOTE_STABLE=https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
 GIT_REMOTE_WSL2=https://github.com/microsoft/WSL2-Linux-Kernel.git
 GIT_REMOTE_NOBLE=git://git.launchpad.net/~ubuntu-kernel/ubuntu/+source/linux/+git/noble
+GIT_REMOTE_LKL=https://github.com/lkl/linux.git
 
 git_check_tag ()
 {
@@ -38,6 +39,7 @@ git_kernel_init ()
     git remote add stable ${GIT_REMOTE_STABLE}
     git remote add wsl2 ${GIT_REMOTE_WSL2}
     git remote add ubuntu-noble ${GIT_REMOTE_NOBLE}
+    git remote add lk-library ${GIT_REMOTE_LKL}
 }
 
 git_kernel_update ()


### PR DESCRIPTION
Add a new remote to the Linux Kernel Library repo. This is a project for running Linux kernel code in userspace.