### PR TITLE
ci: add shellcheck, expand PR testing, and add release workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly

--- a/.github/workflows/build-amdgpu-dkms-test.yml
+++ b/.github/workflows/build-amdgpu-dkms-test.yml
@@ -13,7 +13,6 @@ jobs:
     name: build-amdgpu-dkms-test
     runs-on: ubuntu-24.04
     env:
-      KERNEL_VER: 6.8.0-136-generic
       AMDGPU_REF: rocm-6.2.4
       INSTALL: 'no'
 
@@ -24,6 +23,13 @@ jobs:
       - name: Fix git warning
         run: git config --global init.defaultBranch main
 
+      - name: Detect available kernel headers version
+        id: kver
+        run: |
+          KVER=$(apt-cache search 'linux-headers-[0-9]' | grep generic | \
+                 sort -V | tail -1 | awk '{print $1}' | sed 's/linux-headers-//')
+          echo "kver=${KVER}" >> "$GITHUB_OUTPUT"
+
       - name: Install build dependencies
         run: |
           sudo apt-get update
@@ -33,7 +39,7 @@ jobs:
             build-essential \
             dkms \
             dwarves \
-            linux-headers-${KERNEL_VER}
+            linux-headers-${{ steps.kver.outputs.kver }}
 
       - name: Run the init-update script to populate src/
         run: ./scripts/init-update
@@ -48,7 +54,7 @@ jobs:
       - name: Run build-amdgpu-dkms
         run: ./scripts/build-amdgpu-dkms
         env:
-          KERNEL_VER: ${{ env.KERNEL_VER }}
+          KERNEL_VER: ${{ steps.kver.outputs.kver }}
           AMDGPU_REF: ${{ env.AMDGPU_REF }}
           INSTALL: ${{ env.INSTALL }}
 
@@ -56,3 +62,11 @@ jobs:
         run: |
           dkms status | grep amdgpu
           find /var/lib/dkms/amdgpu -name "*.ko*" | sort
+
+      - name: Verify force-rebuild path (idempotency with FORCE=yes)
+        run: ./scripts/build-amdgpu-dkms
+        env:
+          KERNEL_VER: ${{ steps.kver.outputs.kver }}
+          AMDGPU_REF: ${{ env.AMDGPU_REF }}
+          INSTALL: ${{ env.INSTALL }}
+          FORCE: 'yes'

--- a/.github/workflows/build-amdgpu-dkms-test.yml
+++ b/.github/workflows/build-amdgpu-dkms-test.yml
@@ -26,8 +26,8 @@ jobs:
       - name: Detect available kernel headers version
         id: kver
         run: |
-          # rocm-6.2.4 supports kernel 6.x only; restrict search to 6.x headers
-          KVER=$(apt-cache search 'linux-headers-6\.' | grep generic | \
+          # rocm-6.2.4 supports the 6.8.x kernel series on Ubuntu 24.04
+          KVER=$(apt-cache search 'linux-headers-6\.8\.' | grep generic | \
                  sort -V | tail -1 | awk '{print $1}' | sed 's/linux-headers-//')
           echo "kver=${KVER}" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/build-amdgpu-dkms-test.yml
+++ b/.github/workflows/build-amdgpu-dkms-test.yml
@@ -26,7 +26,8 @@ jobs:
       - name: Detect available kernel headers version
         id: kver
         run: |
-          KVER=$(apt-cache search 'linux-headers-[0-9]' | grep generic | \
+          # rocm-6.2.4 supports kernel 6.x only; restrict search to 6.x headers
+          KVER=$(apt-cache search 'linux-headers-6\.' | grep generic | \
                  sort -V | tail -1 | awk '{print $1}' | sed 's/linux-headers-//')
           echo "kver=${KVER}" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/build-remote-test.yml
+++ b/.github/workflows/build-remote-test.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   build-remote-test:
+    name: build-remote-test (${{ matrix.mode }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -20,19 +21,23 @@ jobs:
             REMOTE_NAME: localhost
             CONFIG: test-config
             CONFIG_SCRIPT: default
-            WSL_MODE: false
-            NO_INSTALL: false
+            WSL_MODE: 'false'
+            NO_BUILD: 'true'
+            NO_INSTALL: 'true'
             LABEL: -build-remote-localhost-test
+            CONFIG_GREP: CONFIG_BLK_DEV_NVME
           - mode: wsl
             CHECK_OUT: wsl2/linux-msft-wsl-6.6.y
             REMOTE_NAME: none
             CONFIG: none
             CONFIG_SCRIPT: wsl
-            WSL_MODE: true
-            NO_INSTALL: true
+            WSL_MODE: 'true'
+            NO_BUILD: 'true'
+            NO_INSTALL: 'true'
             LABEL: -build-remote-wsl-test
+            CONFIG_GREP: CONFIG_INFINIBAND
     steps:
-    - name: Check out code.
+    - name: Check out code
       uses: actions/checkout@v4.2.2
     - name: Fix git warning
       run: git config --global init.defaultBranch main
@@ -48,23 +53,24 @@ jobs:
           libssl-dev \
           nasm \
           pahole
-    - name: Run the init-update script to obtain kernel (${{matrix.mode}} mode)
+    - name: Run the init-update script to obtain kernel (${{ matrix.mode }} mode)
       run: ./scripts/init-update
       env:
         CHECK_OUT: ${{ matrix.CHECK_OUT }}
         GIT_DEPTH: 1
     - name: Generate a default kernel config file
       run: make defconfig && mv .config test-config
-      working-directory:
-        ./src
-    - name: Run the build-remote script (${{matrix.mode}} mode)
+      working-directory: ./src
+    - name: Run the build-remote script (${{ matrix.mode }} mode)
       run: ../scripts/build-remote
-      working-directory:
-        ./src
+      working-directory: ./src
       env:
         REMOTE_NAME: ${{ matrix.REMOTE_NAME }}
         CONFIG: ${{ matrix.CONFIG }}
         CONFIG_SCRIPT: ${{ matrix.CONFIG_SCRIPT }}
         WSL_MODE: ${{ matrix.WSL_MODE }}
+        NO_BUILD: ${{ matrix.NO_BUILD }}
         NO_INSTALL: ${{ matrix.NO_INSTALL }}
         LABEL: ${{ matrix.LABEL }}
+    - name: Verify config-script fragment was applied (${{ matrix.mode }} mode)
+      run: grep "${{ matrix.CONFIG_GREP }}" src/.config

--- a/.github/workflows/init-update-test.yml
+++ b/.github/workflows/init-update-test.yml
@@ -16,13 +16,15 @@ jobs:
       CHECK_OUT: yes
       GIT_DEPTH: 1
     steps:
-    - name: Check out code.
+    - name: Check out code
       uses: actions/checkout@v4.2.2
     - name: Fix git warning
       run: git config --global init.defaultBranch main
     - name: Run the init-update script
       run: ./scripts/init-update
-    - name: Run the init-update script again
+    - name: Verify src/ is a valid git repo with expected remotes
+      run: git -C src remote -v | grep linus
+    - name: Run the init-update script again (idempotency check)
       run: ./scripts/init-update
     - name: Run the init-update script and do a wsl-based branch
       run: ./scripts/init-update

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    name: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4.2.2
+
+      - name: Create release tarballs
+        run: |
+          tar czf "io-uring-dmabuf-patches-${{ github.ref_name }}.tar.gz" patches/io-uring-dmabuf/
+          tar czf "p2pdma-patches-${{ github.ref_name }}.tar.gz" patches/p2pdma/
+          tar czf "useful-configs-${{ github.ref_name }}.tar.gz" useful-configs/
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            io-uring-dmabuf-patches-*.tar.gz
+            p2pdma-patches-*.tar.gz
+            useful-configs-*.tar.gz
+          generate_release_notes: true

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,30 @@
+name: shellcheck
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  shellcheck:
+    name: shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4.2.2
+      - name: Install shellcheck
+        run: sudo apt-get install -y shellcheck
+      - name: Run shellcheck on all scripts
+        run: |
+          shellcheck -x \
+            scripts/init-update \
+            scripts/build-amdgpu-dkms \
+            scripts/build-remote \
+            scripts/build-kernel-debrpm \
+            scripts/build-latest-io-uring-dmabuf-kernel \
+            scripts/build-latest-p2pdma-kernel \
+            arch-tools/build-arm64 \
+            arch-tools/build-riscv \
+            arch-tools/bnxt-oot-build \
+            arch-tools/bnxt-drv-fix

--- a/.github/workflows/spell-check-test.yml
+++ b/.github/workflows/spell-check-test.yml
@@ -5,17 +5,13 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - '**.md'
-      - '.wordlist.txt'
-      - '.spellcheck.yml'
 
 jobs:
   spell-check-test:
     name: spell-check-test
     runs-on: ubuntu-latest
     steps:
-    - name: Check out code.
+    - name: Check out code
       uses: actions/checkout@v4.2.2
     - name: GitHub Spellcheck Action
       uses: rojopolis/spellcheck-github-actions@0.48.0

--- a/.github/workflows/userspace-build-test.yml
+++ b/.github/workflows/userspace-build-test.yml
@@ -1,0 +1,26 @@
+name: userspace-build-test
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'userspace/**'
+
+jobs:
+  userspace-build-test:
+    name: userspace-build-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4.2.2
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libdrm-dev \
+            liburing-dev
+      - name: Verify Makefile structure (dry run)
+        run: make -n
+        working-directory: userspace/amdgpu-dmabuf-io

--- a/arch-tools/bnxt-drv-fix
+++ b/arch-tools/bnxt-drv-fix
@@ -18,10 +18,10 @@ KERNEL=${KERNEL:-$(uname -r)}
 BNXT_EN_DIR=/lib/modules/${KERNEL}/kernel/drivers/net/ethernet/broadcom/bnxt
 BNXT_RE_DIR=/lib/modules/${KERNEL}/kernel/drivers/infiniband/hw/bnxt_re
 
-mkdir -p ${BNXT_EN_DIR}
-mkdir -p ${BNXT_RE_DIR}
+mkdir -p "${BNXT_EN_DIR}"
+mkdir -p "${BNXT_RE_DIR}"
 
-cp ${BNXT_EN} ${BNXT_EN_DIR}/bnxt_en.ko
-cp ${BNXT_RE} ${BNXT_RE_DIR}/bnxt_re.ko
+cp "${BNXT_EN}" "${BNXT_EN_DIR}/bnxt_en.ko"
+cp "${BNXT_RE}" "${BNXT_RE_DIR}/bnxt_re.ko"
 
 depmod

--- a/arch-tools/bnxt-oot-build
+++ b/arch-tools/bnxt-oot-build
@@ -17,26 +17,26 @@ VERBOSE=${VERBOSE:-no}
 
 THISDIR=$(pwd)
 
-if [ $VERBOSE == "yes" ]; then
+if [ "$VERBOSE" == "yes" ]; then
     echo "ARCH=${ARCH}: CROSS_COMPILE={$CROSS_COMPILE}"
     echo "KDIR=${KDIR}"
     echo "DIR=${DIR}"
 fi
 
-cd $DIR/bnxt_en
-if [ $CLEAN == "yes" ];then
+cd "$DIR/bnxt_en" || exit 1
+if [ "$CLEAN" == "yes" ]; then
     make clean
 fi
-make LINUXSRC=${KDIR}
-cp bnxt_en.ko ${THISDIR}
+make LINUXSRC="${KDIR}"
+cp bnxt_en.ko "${THISDIR}"
 
-cd ../bnxt_re
-if [ $CLEAN == "yes" ];then
+cd ../bnxt_re || exit 1
+if [ "$CLEAN" == "yes" ]; then
     make clean
 fi
-make LINUXSRC=${KDIR} \
-     LINUX=${KDIR} \
-     OFA_KERNEL_PATH=${KDIR}
-cp bnxt_re.ko ${THISDIR}
+make LINUXSRC="${KDIR}" \
+     LINUX="${KDIR}" \
+     OFA_KERNEL_PATH="${KDIR}"
+cp bnxt_re.ko "${THISDIR}"
 
-cd $THISDIR
+cd "$THISDIR" || exit 1

--- a/arch-tools/build-arm64
+++ b/arch-tools/build-arm64
@@ -61,7 +61,7 @@ TIME=$(date +"%m%d%Y-%H%M%S")
 
 #if [ ! -x "${CROSSTOOLS}gcc" ]; then
 #   echo "Error: ${CROSSTOOLS} compile tools do not appear to exist."
-#   exit -1
+#   exit 1
 #fi
 
   # Now run the build process. We also copy the .config somewhere safe
@@ -70,30 +70,32 @@ TIME=$(date +"%m%d%Y-%H%M%S")
 export CROSS_COMPILE=${CROSSTOOLS}
 export ARCH=arm64
 
-rm -rf ${MODULEDIR}
-if [ $CLEAN != "no" ]; then
+rm -rf "${MODULEDIR}"
+if [ "$CLEAN" != "no" ]; then
     make clean
 fi
-cp $CONFIG .config
+cp "$CONFIG" .config
 make oldconfig
-cp .config ../.config-$TIME
-make -j $THREADS
-make INSTALL_MOD_PATH=$MODULEDIR modules_install
-make INSTALL_HDR_PATH=$HEADERDIR headers_install
+cp .config "../.config-$TIME"
+make -j "$THREADS"
+make INSTALL_MOD_PATH="$MODULEDIR" modules_install
+make INSTALL_HDR_PATH="$HEADERDIR" headers_install
 
   # Prep the two things we need to move. The Image file and a tarball
   # of the kernel modules.
 
-mkdir -p ${OUTPUTDIR}-${TIME}
-cp .config ${OUTPUTDIR}-${TIME}/.config-$TIME
-cp arch/arm64/boot/Image ${OUTPUTDIR}-${TIME}/Image-$TIME
-cd ${MODULEDIR}/lib/modules
-tar cvfz modules.tar.gz --exclude=modules.tar.gz *
-cd -
-cp ${MODULEDIR}/lib/modules/modules.tar.gz ${OUTPUTDIR}-${TIME}/modules-$TIME.tar.gz
-tar cvfz headers.tar.gz ${HEADERDIR}
-cp headers.tar.gz ${OUTPUTDIR}-${TIME}/headers-$TIME.tar.gz
-rm -rf ${MODULEDIR} ${HEADERDIR}
+mkdir -p "${OUTPUTDIR}-${TIME}"
+cp .config "${OUTPUTDIR}-${TIME}/.config-$TIME"
+cp arch/arm64/boot/Image "${OUTPUTDIR}-${TIME}/Image-$TIME"
+(
+    cd "${MODULEDIR}/lib/modules" || exit 1
+    # shellcheck disable=SC2035
+    tar cvfz modules.tar.gz --exclude=modules.tar.gz *
+)
+cp "${MODULEDIR}/lib/modules/modules.tar.gz" "${OUTPUTDIR}-${TIME}/modules-$TIME.tar.gz"
+tar cvfz headers.tar.gz "${HEADERDIR}"
+cp headers.tar.gz "${OUTPUTDIR}-${TIME}/headers-$TIME.tar.gz"
+rm -rf "${MODULEDIR}" "${HEADERDIR}"
 
 # Ideally we will add the ability to install the kernel we just built
 # on the arm64 machine. For now here are some instructions for the
@@ -120,6 +122,6 @@ rm -rf ${MODULEDIR} ${HEADERDIR}
 #      ln -s build /usr/src/<name of new kernel>
 #      ln -s source /usr/src/<name of new kernel>
 
-if [ $TARGET_HOST != "none" ]; then
+if [ "$TARGET_HOST" != "none" ]; then
     echo "TBD: scp kernel and modules to target host!"
 fi

--- a/arch-tools/build-riscv
+++ b/arch-tools/build-riscv
@@ -48,7 +48,7 @@
   # by the script caller.
 
 CONFIG=${CONFIG:-.config}
-CROSSTOOLS=${CROSSTOOLS:-risv32-linux-gnu-}
+CROSSTOOLS=${CROSSTOOLS:-riscv32-linux-gnu-}
 MODULEDIR=${MODULEDIR:-../modules-riscv}
 HEADERDIR=${HEADERDIR:-../headers-riscv}
 OUTPUTDIR=${OUTPUTDIR:-../output-riscv}
@@ -62,7 +62,7 @@ TIME=$(date +"%m%d%Y-%H%M%S")
 
 #if [ ! -x "${CROSSTOOLS}gcc" ]; then
 #   echo "Error: ${CROSSTOOLS} compile tools do not appear to exist."
-#   exit -1
+#   exit 1
 #fi
 
   # Now run the build process. We also copy the .config somewhere safe
@@ -71,31 +71,33 @@ TIME=$(date +"%m%d%Y-%H%M%S")
 export CROSS_COMPILE=${CROSSTOOLS}
 export ARCH=riscv
 
-rm -rf ${MODULEDIR}
-if [ $CLEAN != "no" ]; then
+rm -rf "${MODULEDIR}"
+if [ "$CLEAN" != "no" ]; then
     make clean
 fi
-cp $CONFIG .config
+cp "$CONFIG" .config
 make oldconfig
-cp .config ../.config-$TIME
-make -j $THREADS
-make INSTALL_MOD_PATH=$MODULEDIR modules_install
-make INSTALL_HDR_PATH=$HEADERDIR headers_install
+cp .config "../.config-$TIME"
+make -j "$THREADS"
+make INSTALL_MOD_PATH="$MODULEDIR" modules_install
+make INSTALL_HDR_PATH="$HEADERDIR" headers_install
 
   # Prep the two things we need to move. The Image file and a tarball
   # of the kernel modules.
 
-mkdir -p ${OUTPUTDIR}-${TIME}
-cp .config ${OUTPUTDIR}-${TIME}/.config-$TIME
-cp arch/riscv/boot/Image ${OUTPUTDIR}-${TIME}/Image-$TIME
-cd ${MODULEDIR}/lib/modules
-tar cvfz modules.tar.gz --exclude=modules.tar.gz *
-cd -
-cp ${MODULEDIR}/lib/modules/modules.tar.gz ${OUTPUTDIR}-${TIME}/modules-$TIME.tar.gz
-tar cvfz headers.tar.gz ${HEADERDIR}
-cp headers.tar.gz ${OUTPUTDIR}-${TIME}/headers-$TIME.tar.gz
-rm -rf ${MODULEDIR} ${HEADERDIR}
+mkdir -p "${OUTPUTDIR}-${TIME}"
+cp .config "${OUTPUTDIR}-${TIME}/.config-$TIME"
+cp arch/riscv/boot/Image "${OUTPUTDIR}-${TIME}/Image-$TIME"
+(
+    cd "${MODULEDIR}/lib/modules" || exit 1
+    # shellcheck disable=SC2035
+    tar cvfz modules.tar.gz --exclude=modules.tar.gz *
+)
+cp "${MODULEDIR}/lib/modules/modules.tar.gz" "${OUTPUTDIR}-${TIME}/modules-$TIME.tar.gz"
+tar cvfz headers.tar.gz "${HEADERDIR}"
+cp headers.tar.gz "${OUTPUTDIR}-${TIME}/headers-$TIME.tar.gz"
+rm -rf "${MODULEDIR}" "${HEADERDIR}"
 
-if [ $TARGET_HOST != "none" ]; then
+if [ "$TARGET_HOST" != "none" ]; then
     echo "TBD: scp kernel and modules to target host!"
 fi

--- a/scripts/build-amdgpu-dkms
+++ b/scripts/build-amdgpu-dkms
@@ -37,20 +37,20 @@ check_deps ()
 {
     if [ -z "${KERNEL_VER}" ]; then
         echo "Error. KERNEL_VER must be set (e.g. KERNEL_VER=6.8.0-60-generic)."
-        exit -1
+        exit 1
     fi
     if [ ! -d "/lib/modules/${KERNEL_VER}/build" ]; then
         echo "Error. Kernel headers not found at /lib/modules/${KERNEL_VER}/build."
         echo "       Run: sudo apt install linux-headers-${KERNEL_VER}"
-        exit -1
+        exit 1
     fi
     if ! which dkms &> /dev/null; then
         echo "Error. dkms is not installed. Run: sudo apt install dkms"
-        exit -1
+        exit 1
     fi
     if ! which autoconf &> /dev/null || ! which automake &> /dev/null; then
         echo "Error. autoconf/automake not installed. Run: sudo apt install autoconf automake"
-        exit -1
+        exit 1
     fi
     if which ccache &> /dev/null; then
         echo "  INFO: ccache detected, will use for build."
@@ -62,7 +62,7 @@ check_deps ()
 
 get_amdgpu_version ()
 {
-    cd ${KERNEL_DIR}
+    cd "${KERNEL_DIR}"
     # Resolve the ref: try it directly first (covers tags and local branches),
     # then fall back to fetching from the remote (covers remote branches).
     if git rev-parse --verify --quiet "${AMDGPU_REF}^{commit}" &>/dev/null; then
@@ -70,7 +70,7 @@ get_amdgpu_version ()
         GIT_REF="${AMDGPU_REF}"
     else
         echo "  INFO: Fetching ${AMDGPU_REMOTE}/${AMDGPU_REF}..."
-        git fetch ${AMDGPU_REMOTE} ${AMDGPU_REF}
+        git fetch "${AMDGPU_REMOTE}" "${AMDGPU_REF}"
         GIT_REF="FETCH_HEAD"
     fi
     # The upstream dkms.conf always uses PACKAGE_VERSION="1.0" regardless of
@@ -85,15 +85,15 @@ get_amdgpu_version ()
 
 stage_source ()
 {
-    if [ -d "${BUILD_SRC}" ] && [ ${FORCE} == "no" ]; then
+    if [ -d "${BUILD_SRC}" ] && [ "${FORCE}" == "no" ]; then
         echo "  INFO: Source already staged at ${BUILD_SRC}, skipping."
         return
     fi
     echo "  INFO: Staging amdgpu source to ${BUILD_SRC}..."
-    cd ${KERNEL_DIR}
+    cd "${KERNEL_DIR}"
 
-    sudo rm -rf ${BUILD_SRC}
-    sudo mkdir -p ${BUILD_SRC}
+    sudo rm -rf "${BUILD_SRC}"
+    sudo mkdir -p "${BUILD_SRC}"
 
     # Stage exactly what AMD's own 'sources' manifest specifies — no more, no less.
     # This mirrors how the official amdgpu-dkms .deb is assembled: only AMD-specific
@@ -103,61 +103,61 @@ stage_source ()
     # Strip drivers/gpu/drm/ (3 components) so the layout at BUILD_SRC is:
     #   amd/{amdgpu,amdkcl,amdkfd,dkms,...}  ttm/  scheduler/
     echo "  INFO: Extracting drivers/gpu/drm/amd (this may take a while)..."
-    git archive ${GIT_REF} drivers/gpu/drm/amd \
-        | sudo tar -x --strip-components=3 -C ${BUILD_SRC}
+    git archive "${GIT_REF}" drivers/gpu/drm/amd \
+        | sudo tar -x --strip-components=3 -C "${BUILD_SRC}"
 
     echo "  INFO: Extracting drivers/gpu/drm/ttm..."
-    git archive ${GIT_REF} drivers/gpu/drm/ttm \
-        | sudo tar -x --strip-components=3 -C ${BUILD_SRC}
+    git archive "${GIT_REF}" drivers/gpu/drm/ttm \
+        | sudo tar -x --strip-components=3 -C "${BUILD_SRC}"
 
     echo "  INFO: Extracting drivers/gpu/drm/scheduler..."
-    git archive ${GIT_REF} drivers/gpu/drm/scheduler \
-        | sudo tar -x --strip-components=3 -C ${BUILD_SRC}
+    git archive "${GIT_REF}" drivers/gpu/drm/scheduler \
+        | sudo tar -x --strip-components=3 -C "${BUILD_SRC}"
 
     echo "  INFO: Extracting DRM core files carried out-of-tree..."
     for f in drm_gem_ttm_helper.c drm_buddy.c drm_exec.c drm_suballoc.c; do
-        git archive ${GIT_REF} drivers/gpu/drm/${f} \
-            | sudo tar -x --strip-components=3 -C ${BUILD_SRC}
+        git archive "${GIT_REF}" drivers/gpu/drm/${f} \
+            | sudo tar -x --strip-components=3 -C "${BUILD_SRC}"
     done
 
     echo "  INFO: Extracting include/kcl..."
-    sudo mkdir -p ${BUILD_SRC}/include
-    git archive ${GIT_REF} include/kcl \
-        | sudo tar -x --strip-components=1 -C ${BUILD_SRC}/include
+    sudo mkdir -p "${BUILD_SRC}/include"
+    git archive "${GIT_REF}" include/kcl \
+        | sudo tar -x --strip-components=1 -C "${BUILD_SRC}/include"
 
     echo "  INFO: Extracting AMD-specific DRM headers..."
-    sudo mkdir -p ${BUILD_SRC}/include/drm
-    git archive ${GIT_REF} include/drm/ttm \
-        | sudo tar -x --strip-components=2 -C ${BUILD_SRC}/include/drm
+    sudo mkdir -p "${BUILD_SRC}/include/drm"
+    git archive "${GIT_REF}" include/drm/ttm \
+        | sudo tar -x --strip-components=2 -C "${BUILD_SRC}/include/drm"
     for f in amd_asic_type.h amd_rdma.h spsc_queue.h \
               drm_buddy.h drm_exec.h drm_gem_ttm_helper.h gpu_scheduler.h; do
-        git archive ${GIT_REF} include/drm/${f} 2>/dev/null \
-            | sudo tar -x --strip-components=2 -C ${BUILD_SRC}/include/drm || true
+        git archive "${GIT_REF}" include/drm/${f} 2>/dev/null \
+            | sudo tar -x --strip-components=2 -C "${BUILD_SRC}/include/drm" || true
     done
 
     echo "  INFO: Extracting uapi headers..."
-    sudo mkdir -p ${BUILD_SRC}/include/uapi/drm
-    sudo mkdir -p ${BUILD_SRC}/include/uapi/linux
-    git archive ${GIT_REF} include/uapi/drm/amdgpu_drm.h \
-        | sudo tar -x --strip-components=3 -C ${BUILD_SRC}/include/uapi/drm
+    sudo mkdir -p "${BUILD_SRC}/include/uapi/drm"
+    sudo mkdir -p "${BUILD_SRC}/include/uapi/linux"
+    git archive "${GIT_REF}" include/uapi/drm/amdgpu_drm.h \
+        | sudo tar -x --strip-components=3 -C "${BUILD_SRC}/include/uapi/drm"
     for f in kfd_ioctl.h kfd_sysfs.h; do
-        git archive ${GIT_REF} include/uapi/linux/${f} 2>/dev/null \
-            | sudo tar -x --strip-components=3 -C ${BUILD_SRC}/include/uapi/linux || true
+        git archive "${GIT_REF}" include/uapi/linux/${f} 2>/dev/null \
+            | sudo tar -x --strip-components=3 -C "${BUILD_SRC}/include/uapi/linux" || true
     done
 
     echo "  INFO: Extracting dma-resv..."
-    sudo mkdir -p ${BUILD_SRC}/amd/amdkcl/dma-buf
-    git archive ${GIT_REF} drivers/dma-buf/dma-resv.c \
-        | sudo tar -x --strip-components=2 -C ${BUILD_SRC}/amd/amdkcl/dma-buf
-    sudo mkdir -p ${BUILD_SRC}/include/linux
-    git archive ${GIT_REF} include/linux/dma-resv.h \
-        | sudo tar -x --strip-components=2 -C ${BUILD_SRC}/include/linux
-    git archive ${GIT_REF} include/kcl/reservation.h 2>/dev/null \
-        | sudo tar -x --strip-components=2 -C ${BUILD_SRC}/include/linux || true
+    sudo mkdir -p "${BUILD_SRC}/amd/amdkcl/dma-buf"
+    git archive "${GIT_REF}" drivers/dma-buf/dma-resv.c \
+        | sudo tar -x --strip-components=2 -C "${BUILD_SRC}/amd/amdkcl/dma-buf"
+    sudo mkdir -p "${BUILD_SRC}/include/linux"
+    git archive "${GIT_REF}" include/linux/dma-resv.h \
+        | sudo tar -x --strip-components=2 -C "${BUILD_SRC}/include/linux"
+    git archive "${GIT_REF}" include/kcl/reservation.h 2>/dev/null \
+        | sudo tar -x --strip-components=2 -C "${BUILD_SRC}/include/linux" || true
 
     echo "  INFO: Setting up Makefile and dkms.conf at source root..."
-    sudo ln -sf amd/dkms/Makefile ${BUILD_SRC}/Makefile
-    sudo ln -sf amd/dkms/dkms.conf ${BUILD_SRC}/dkms.conf
+    sudo ln -sf amd/dkms/Makefile "${BUILD_SRC}/Makefile"
+    sudo ln -sf amd/dkms/dkms.conf "${BUILD_SRC}/dkms.conf"
 
     # Generate configure using the full autotools chain so pre-build.sh can
     # produce config/config.h with correct per-kernel HAVE_* compat flags.
@@ -175,11 +175,11 @@ stage_source ()
         sudo touch "${KBUILD}/include/generated/rq-offsets.h"
     fi
 
-    if [ ${USE_CCACHE} == "yes" ]; then
+    if [ "${USE_CCACHE}" == "yes" ]; then
         echo "  INFO: Injecting ccache into ${BUILD_SRC}/amd/dkms/dkms.conf."
         sudo sed -i \
             's|^\(MAKE\[0\]="[^"]*make \)|\1CC='"'"'ccache gcc'"'"' |' \
-            ${BUILD_SRC}/amd/dkms/dkms.conf
+            "${BUILD_SRC}/amd/dkms/dkms.conf"
     fi
     SOURCE_STAGED=yes
 }
@@ -189,7 +189,7 @@ apply_patches ()
     if [ -z "${PATCH_DIRS}" ]; then
         return
     fi
-    if [ "${SOURCE_STAGED}" != "yes" ] && [ ${FORCE} == "no" ]; then
+    if [ "${SOURCE_STAGED}" != "yes" ] && [ "${FORCE}" == "no" ]; then
         echo "  INFO: Source was not re-staged, skipping patch application."
         return
     fi
@@ -197,7 +197,7 @@ apply_patches ()
     for dir in "${dir_list[@]}"; do
         if [ ! -d "${dir}" ]; then
             echo "Error. Patch directory '${dir}' does not exist."
-            exit -1
+            exit 1
         fi
         mapfile -t patches < <(find "${dir}" -maxdepth 1 -name '*.patch' | sort -V)
         if [ ${#patches[@]} -eq 0 ]; then
@@ -206,11 +206,12 @@ apply_patches ()
         fi
         echo "  INFO: Applying ${#patches[@]} patch(es) from '${dir}'..."
         for patch_file in "${patches[@]}"; do
-            echo "  INFO: Applying $(basename ${patch_file})..."
+            echo "  INFO: Applying $(basename "${patch_file}")..."
             # Patches use paths relative to the amd/ subtree (e.g. a/amd/amdgpu/...).
             # BUILD_SRC contains amd/ after --strip-components=3, so -p1 strips
             # the leading a/ leaving amd/amdgpu/... relative to BUILD_SRC.
-            sudo patch -d ${BUILD_SRC} -p1 --fuzz=3 < "${patch_file}"
+            # shellcheck disable=SC2024
+            sudo patch -d "${BUILD_SRC}" -p1 --fuzz=3 < "${patch_file}"
         done
     done
 }
@@ -218,47 +219,49 @@ apply_patches ()
 
 dkms_add ()
 {
-    if sudo dkms status -m amdgpu -v ${AMDGPU_VER} 2>/dev/null | grep -q amdgpu \
-            && [ ${FORCE} == "no" ]; then
+    if sudo dkms status -m amdgpu -v "${AMDGPU_VER}" 2>/dev/null | grep -q amdgpu \
+            && [ "${FORCE}" == "no" ]; then
         echo "  INFO: amdgpu ${AMDGPU_VER} already registered with DKMS, skipping add."
         return
     fi
     echo "  INFO: Registering amdgpu ${AMDGPU_VER} with DKMS..."
-    if [ ${FORCE} == "yes" ]; then
-        sudo dkms remove -m amdgpu -v ${AMDGPU_VER} --all 2>/dev/null || true
+    if [ "${FORCE}" == "yes" ]; then
+        sudo dkms remove -m amdgpu -v "${AMDGPU_VER}" --all 2>/dev/null || true
     fi
-    sudo dkms add -m amdgpu -v ${AMDGPU_VER}
+    sudo dkms add -m amdgpu -v "${AMDGPU_VER}"
 }
 
 dkms_build ()
 {
-    if sudo dkms status -m amdgpu -v ${AMDGPU_VER} -k ${KERNEL_VER} 2>/dev/null \
-            | grep -qE 'built|installed' && [ ${FORCE} == "no" ]; then
+    if sudo dkms status -m amdgpu -v "${AMDGPU_VER}" -k "${KERNEL_VER}" 2>/dev/null \
+            | grep -qE 'built|installed' && [ "${FORCE}" == "no" ]; then
         echo "  INFO: amdgpu ${AMDGPU_VER} already built for ${KERNEL_VER}, skipping build."
         return
     fi
     FORCE_FLAG=""
-    if [ ${FORCE} == "yes" ]; then
+    if [ "${FORCE}" == "yes" ]; then
         FORCE_FLAG="--force"
     fi
     echo "  INFO: Building amdgpu ${AMDGPU_VER} for kernel ${KERNEL_VER} with $(nproc) jobs..."
-    sudo dkms build -m amdgpu -v ${AMDGPU_VER} -k ${KERNEL_VER} \
+    # shellcheck disable=SC2046
+    sudo dkms build -m amdgpu -v "${AMDGPU_VER}" -k "${KERNEL_VER}" \
         -j $(nproc) ${FORCE_FLAG}
 }
 
 dkms_install ()
 {
-    if sudo dkms status -m amdgpu -v ${AMDGPU_VER} -k ${KERNEL_VER} 2>/dev/null \
-            | grep -q installed && [ ${FORCE} == "no" ]; then
+    if sudo dkms status -m amdgpu -v "${AMDGPU_VER}" -k "${KERNEL_VER}" 2>/dev/null \
+            | grep -q installed && [ "${FORCE}" == "no" ]; then
         echo "  INFO: amdgpu ${AMDGPU_VER} already installed for ${KERNEL_VER}, skipping install."
         return
     fi
     FORCE_FLAG=""
-    if [ ${FORCE} == "yes" ]; then
+    if [ "${FORCE}" == "yes" ]; then
         FORCE_FLAG="--force"
     fi
     echo "  INFO: Installing amdgpu ${AMDGPU_VER} for kernel ${KERNEL_VER}..."
-    sudo dkms install -m amdgpu -v ${AMDGPU_VER} -k ${KERNEL_VER} ${FORCE_FLAG}
+    # shellcheck disable=SC2086
+    sudo dkms install -m amdgpu -v "${AMDGPU_VER}" -k "${KERNEL_VER}" ${FORCE_FLAG}
 }
 
 check_deps
@@ -267,7 +270,7 @@ stage_source
 apply_patches
 dkms_add
 dkms_build
-if [ ${INSTALL} == "yes" ]; then
+if [ "${INSTALL}" == "yes" ]; then
     dkms_install
 fi
 echo "  INFO: amdgpu DKMS ${AMDGPU_VER} complete for kernel ${KERNEL_VER}."

--- a/scripts/build-kernel-debrpm
+++ b/scripts/build-kernel-debrpm
@@ -8,14 +8,14 @@
 #
 # Note that by default this will be a stable kernel with default
 # config options for the ARCH of the host machine. To build for
-# another ARCH set the ARCH and CROSS_COMPILE inputs appropriately. 
+# another ARCH set the ARCH and CROSS_COMPILE inputs appropriately.
 #
 # An example call to this script that builds a working p2pmem kernel
 # (only on AMD or x86_64) is as follows:
 #
 # REMOTE=https://github.com/sbates130272/linux-p2pmem \
 #   REMOTE_BRANCH=pci-p2p-v4 \
-#   CONFIG=build-kernel-deb-p2pconfig \  
+#   CONFIG=build-kernel-deb-p2pconfig \
 #   ./build-kernel-debrpm
 #
 # You can build a monolithic kernel by calling with MONO=yes. You can
@@ -47,59 +47,59 @@ CURDIR=$(pwd)
 
 # Can't do both DISTCC and ICECC!
 
-if [ $DISTCC == "yes" ] && [ $ICECC == "yes" ]; then
+if [ "$DISTCC" == "yes" ] && [ "$ICECC" == "yes" ]; then
     echo "You cannot set both DISTCC and ICECC!"
     exit 1
 fi
 
 # If requested, setup for a cross compile
 
-if [ ! -z $ARCH ]; then
+if [ -n "$ARCH" ]; then
     export ARCH=${ARCH}
     export CROSS_COMPILE=${CROSS_COMPILE}
-fi;
+fi
 
 function cleanup() {
-    rm -rf ../linux-${1}*.tar.gz \
-       ../linux-${1}*.diff.gz \
-       ../linux-headers-${1}*.deb \
-       ../linux-libc-dev_${1}*.deb \
-       ../linux-image-${1}*.deb \
-       ../linux-${1}*.dsc \
-       ../linux-${1}*.changes \
-       ../linux-${1}*.buildinfo
+    rm -rf "../linux-${1}"*.tar.gz \
+       "../linux-${1}"*.diff.gz \
+       "../linux-headers-${1}"*.deb \
+       "../linux-libc-dev_${1}"*.deb \
+       "../linux-image-${1}"*.deb \
+       "../linux-${1}"*.dsc \
+       "../linux-${1}"*.changes \
+       "../linux-${1}"*.buildinfo
 }
 
   # Perform a shallow (depth 1) clone of the target kernel repo into
   # the work folder. Best to use a temp folder for this.
 
-git clone --depth 1 $REMOTE -b $REMOTE_BRANCH $WORKDIR/kernel
-cd $WORKDIR/kernel
+git clone --depth 1 "$REMOTE" -b "$REMOTE_BRANCH" "$WORKDIR/kernel"
+cd "$WORKDIR/kernel"
 
   # Apply a patch file if one exists. If PATCH is a directory we apply
   # all the *.patch files in that folder.
 
 function patchdir() {
-    for file in $(find $1 -name "*.patch" | sort -n) ; do
-	echo Applying patch-file $file.
-	cat $file | patch -p1 -l
-    done
+    while IFS= read -r -d '' file; do
+        echo "Applying patch-file $file."
+        patch -p1 -l < "$file"
+    done < <(find "$1" -name "*.patch" -print0 | sort -zn)
 }
 
-if [ ! -z $PATCH ]; then
-    if [[ -d $CURDIR/$PATCH ]]; then
-	patchdir $CURDIR/$PATCH
+if [ -n "$PATCH" ]; then
+    if [[ -d "$CURDIR/$PATCH" ]]; then
+        patchdir "$CURDIR/$PATCH"
     else
-	echo "Applying patch-file $CURDIR/${PATCH}."
-	cat $CURDIR/$PATCH | patch -p1
+        echo "Applying patch-file $CURDIR/${PATCH}."
+        patch -p1 < "$CURDIR/$PATCH"
     fi
 fi
 
   # If requested copy in the specified .config to use as a start
   # point. If none is specified then we just run a make defconfig.
 
-if [ ! -z $CONFIG ]; then
-    cp $CURDIR/$CONFIG .config
+if [ -n "$CONFIG" ]; then
+    cp "$CURDIR/$CONFIG" .config
     make olddefconfig
 else
     make defconfig
@@ -108,7 +108,7 @@ fi
   # By default, disable debug information since this increases the
   # build time hugely.
 
-if [ $DEBUG != "yes" ]; then
+if [ "$DEBUG" != "yes" ]; then
     scripts/config --disable DEBUG_INFO
 fi
 
@@ -116,7 +116,7 @@ fi
   # requested then run make localyesconfig. Note this results in a
   # much bigger image file but no need for modules.
 
-if [ $MONO == "yes" ]; then
+if [ "$MONO" == "yes" ]; then
     make localyesconfig
 fi
 
@@ -124,18 +124,21 @@ fi
   # distcc if requested. In the case of RPM pass in RPM opts to use
   # the current folder as the parent for rpmbuild folder.
 
-if [ $DEB == "yes" ]; then
+if [ "$DEB" == "yes" ]; then
     TARGET=deb-pkg
 else
     TARGET=rpm-pkg
 fi
 
-if [ $DISTCC == "yes" ]; then
-    distcc-pump make RPMOPTS="--define \"_topdir `pwd`/rpmbuild\"" -j $THREADS CC=distcc $TARGET
-elif [ $ICECC == "yes" ]; then
-    make RPMOPTS="--define \"_topdir `pwd`/rpmbuild\"" -j $THREADS CC="icecc cc" $TARGET
+if [ "$DISTCC" == "yes" ]; then
+    # shellcheck disable=SC2046
+    distcc-pump make RPMOPTS="--define \"_topdir $(pwd)/rpmbuild\"" -j "$THREADS" CC=distcc $TARGET
+elif [ "$ICECC" == "yes" ]; then
+    # shellcheck disable=SC2046
+    make RPMOPTS="--define \"_topdir $(pwd)/rpmbuild\"" -j "$THREADS" CC="icecc cc" $TARGET
 else
-    make RPMOPTS="--define \"_topdir `pwd`/rpmbuild\"" -j $THREADS $TARGET
+    # shellcheck disable=SC2046
+    make RPMOPTS="--define \"_topdir $(pwd)/rpmbuild\"" -j "$THREADS" $TARGET
 fi
 
 VERSION=$(make -s kernelversion)
@@ -149,17 +152,17 @@ cat > .build-info << EOF
 EOF
 
 FILES=(.config .build-info)
-if [ ! -z $PATCH ]; then
-    if [[ -d $CURDIR/$PATCH ]]; then
-	for file in $(find $CURDIR/$PATCH -name "*.patch") ; do
-	    FILES+=($file)
-	done
+if [ -n "$PATCH" ]; then
+    if [[ -d "$CURDIR/$PATCH" ]]; then
+        while IFS= read -r -d '' file; do
+            FILES+=("$file")
+        done < <(find "$CURDIR/$PATCH" -name "*.patch" -print0)
     else
-	FILES+=(${CURDIR}/$PATCH)
+        FILES+=("${CURDIR}/$PATCH")
     fi
 fi
 
-if [ $DEB == "yes" ]; then
+if [ "$DEB" == "yes" ]; then
 
     # By default (and this seems hard to change) the deb-pkg make target
     # generates the files in parent folder. We grab the kernel version
@@ -167,27 +170,26 @@ if [ $DEB == "yes" ]; then
     # add the .config for reference as well as the remote, branch and
     # commit SHA used.
 
-
-    tar cvfz ${CURDIR}/build-kernel-deb.${TIME}.tar.gz \
-	../linux-headers-${VERSION}*.deb \
-	../linux-image-${VERSION}*.deb \
-	${FILES[*]}
+    tar cvfz "${CURDIR}/build-kernel-deb.${TIME}.tar.gz" \
+        "../linux-headers-${VERSION}"*.deb \
+        "../linux-image-${VERSION}"*.deb \
+        "${FILES[@]}"
 
 else
 
-    if [ -z $ARCH ]; then
-	ARCH=$(lscpu | head -n 1 | awk '{print $2}')
+    if [ -z "$ARCH" ]; then
+        ARCH=$(lscpu | head -n 1 | awk '{print $2}')
     fi
 
-    tar cvfz ${CURDIR}/build-kernel-rpm.${TIME}.tar.gz \
-	./rpmbuild/RPMS/${ARCH}/kernel-*.rpm \
-	kernel.spec \
-	${FILES[*]}
+    tar cvfz "${CURDIR}/build-kernel-rpm.${TIME}.tar.gz" \
+        "./rpmbuild/RPMS/${ARCH}/kernel-"*.rpm \
+        kernel.spec \
+        "${FILES[@]}"
 
 fi
 
   # Cleanup
 
-cleanup ${VERSION}
-cd $CURDIR
-rm -rf ${WORKDIR}
+cleanup "${VERSION}"
+cd "$CURDIR"
+rm -rf "${WORKDIR}"

--- a/scripts/build-remote
+++ b/scripts/build-remote
@@ -59,46 +59,47 @@ WSL_CONFIG=/mnt/c/Users/${WIN_USER}/.wslconfig
 # Get script path
 SCRIPT_DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd)
 
-if [ ${WSL_MODE} == "true" ]; then
+if [ "${WSL_MODE}" == "true" ]; then
     echo "INFO: Executing in WSL mode."
     REMOTE_NAME=localhost
     CONFIG=config-wsl
 else
-    if [ ${REMOTE_NAME} == "none" ]; then
-        echo "Error. You must specify a REMOTE_NAME to ssh into."; exit -1
+    if [ "${REMOTE_NAME}" == "none" ]; then
+        echo "Error. You must specify a REMOTE_NAME to ssh into."; exit 1
     fi
-    if [ ${CONFIG} == "none" ]; then
-        echo "Error. You must specify a CONFIG file."; exit -1
+    if [ "${CONFIG}" == "none" ]; then
+        echo "Error. You must specify a CONFIG file."; exit 1
     fi
 fi
 
 function clean {
     make distclean
+    # shellcheck disable=SC2035
     rm -rf linux-*.tar.gz \
-       *-lsmod \
+       -- *-lsmod \
        config-* \
-       *.vhdx \
+       -- *.vhdx \
        wslconfig-* \
-       ${REMOTE_NAME}-${CONFIG}
+       "${REMOTE_NAME}-${CONFIG}"
 }
 
 function setup {
-    if [ ${WSL_MODE} == "true" ]; then
-        cp ./Microsoft/${CONFIG} ${REMOTE_NAME}-${CONFIG}
-        lsmod > ${REMOTE_NAME}-${CONFIG}-lsmod
-    elif [ ${REMOTE_NAME} == "localhost" ]; then
-        if [ ! -f ${CONFIG} ]; then
-            echo "Error: localhost CONFIG (${CONFIG}) does not exist."; exit -1
+    if [ "${WSL_MODE}" == "true" ]; then
+        cp "./Microsoft/${CONFIG}" "${REMOTE_NAME}-${CONFIG}"
+        lsmod > "${REMOTE_NAME}-${CONFIG}-lsmod"
+    elif [ "${REMOTE_NAME}" == "localhost" ]; then
+        if [ ! -f "${CONFIG}" ]; then
+            echo "Error: localhost CONFIG (${CONFIG}) does not exist."; exit 1
         fi
-        cp ${CONFIG} ${REMOTE_NAME}-${CONFIG}
-        lsmod > ${REMOTE_NAME}-${CONFIG}-lsmod
+        cp "${CONFIG}" "${REMOTE_NAME}-${CONFIG}"
+        lsmod > "${REMOTE_NAME}-${CONFIG}-lsmod"
     else
-        scp -F ${HOME}/.ssh/config \
-            ${REMOTE_NAME}:/boot/${CONFIG} ${REMOTE_NAME}-${CONFIG}
-        ssh -F ${HOME}/.ssh/config ${REMOTE_NAME} \
-            lsmod > ${REMOTE_NAME}-${CONFIG}-lsmod
+        scp -F "${HOME}/.ssh/config" \
+            "${REMOTE_NAME}:/boot/${CONFIG}" "${REMOTE_NAME}-${CONFIG}"
+        ssh -F "${HOME}/.ssh/config" "${REMOTE_NAME}" \
+            lsmod > "${REMOTE_NAME}-${CONFIG}-lsmod"
     fi
-    cp ${REMOTE_NAME}-${CONFIG} .config
+    cp "${REMOTE_NAME}-${CONFIG}" .config
 
     scripts/config --disable SYSTEM_TRUSTED_KEYRING
     scripts/config --disable SYSTEM_TRUSTED_KEYS
@@ -106,66 +107,70 @@ function setup {
     make olddefconfig
     scripts/config --disable GPIO_BT8XX
     scripts/config --module BLK_DEV_NULL_BLK
-    make LSMOD=${REMOTE_NAME}-${CONFIG}-lsmod localmodconfig
+    make LSMOD="${REMOTE_NAME}-${CONFIG}-lsmod" localmodconfig
     ./scripts/config --enable LOCALVERSION_AUTO
-    ./scripts/config --set-str LOCALVERSION ${LABEL}
+    ./scripts/config --set-str LOCALVERSION "${LABEL}"
 
-    if [ ${CONFIG_SCRIPT} != "none" ]; then
+    if [ "${CONFIG_SCRIPT}" != "none" ]; then
         echo "INFO: Applying the .config mods in config-${CONFIG_SCRIPT}."
-        source ${SCRIPT_DIR}/../config-scripts/config-${CONFIG_SCRIPT}
+        # shellcheck disable=SC1090
+        source "${SCRIPT_DIR}/../config-scripts/config-${CONFIG_SCRIPT}"
     fi
 
     make olddefconfig
 }
 
 function build {
-    if [ ${WSL_MODE} == "true" ]; then
+    if [ "${WSL_MODE}" == "true" ]; then
+        # shellcheck disable=SC2046
         time make -j $(nproc)
         MODULES_PATH=./modules-${VERSION}
-        time INSTALL_MOD_PATH=${MODULES_PATH} make -j $(nproc) \
+        # shellcheck disable=SC2046
+        time INSTALL_MOD_PATH="${MODULES_PATH}" make -j $(nproc) \
              modules_install
     else
+        # shellcheck disable=SC2046
         time make -j $(nproc) targz-pkg
     fi
 }
 
 function install {
-    if [ ${WSL_MODE} == "true" ]; then
+    if [ "${WSL_MODE}" == "true" ]; then
         echo "INSTALL: Installing via WSL_MODE (${VERSION})."
         MODULES_PATH=./modules-${VERSION}
         sudo ./Microsoft/scripts/gen_modules_vhdx.sh \
-             ${MODULES_PATH} \
-             ${VERSION} \
-             modules-${VERSION}.vhdx &> /dev/null
-        sudo chown $(id -u):$(id -g) modules-${VERSION}.vhdx
-        rm -rf ${MODULES_PATH}
-        cp ./arch/${ARCH}/boot/bzImage ${WSL_KERNEL_DIR}/bzImage-${VERSION}
-        cp modules-${VERSION}.vhdx ${WSL_KERNEL_DIR}/modules/
-        WIN_KERNEL_DIR=$(wslpath  -w ${WSL_KERNEL_DIR} | sed s/\\\\/\\\\\\\\\/g)
-        cat <<- EOF > wslconfig-${VERSION}
+             "${MODULES_PATH}" \
+             "${VERSION}" \
+             "modules-${VERSION}.vhdx" &> /dev/null
+        sudo chown "$(id -u):$(id -g)" "modules-${VERSION}.vhdx"
+        rm -rf "${MODULES_PATH}"
+        cp "./arch/${ARCH}/boot/bzImage" "${WSL_KERNEL_DIR}/bzImage-${VERSION}"
+        cp "modules-${VERSION}.vhdx" "${WSL_KERNEL_DIR}/modules/"
+        WIN_KERNEL_DIR=$(wslpath  -w "${WSL_KERNEL_DIR}" | sed 's/\\/\\\\/g')
+        cat <<- EOF > "wslconfig-${VERSION}"
 	[wsl2]
 	kernel=${WIN_KERNEL_DIR}\\\bzImage-${VERSION}
 	kernelModules=${WIN_KERNEL_DIR}\\\modules\\\modules-${VERSION}.vhdx
 	kernelCommandLine=
 	EOF
-        cp ${WSL_CONFIG} ${WSL_CONFIG}.backup
-        cp wslconfig-${VERSION} ${WSL_CONFIG}
-    elif [ ${REMOTE_NAME} == "localhost" ]; then
+        cp "${WSL_CONFIG}" "${WSL_CONFIG}.backup"
+        cp "wslconfig-${VERSION}" "${WSL_CONFIG}"
+    elif [ "${REMOTE_NAME}" == "localhost" ]; then
         echo "INSTALL: Installing with REMOTE=localhost (${VERSION})."
         echo "  INSTALL: In localhost mode do nothing for install (for now)."
     else
         TARBALL=$(ls linux-*.tar.gz)
         echo "INSTALL: Installing ${TARBALL} (${VERSION}) on ${REMOTE_NAME}."
-        scp -F ${HOME}/.ssh/config ${TARBALL} ${REMOTE_NAME}:/tmp/
-        ssh -F ${HOME}/.ssh/config -t -t ${REMOTE_NAME} \
+        scp -F "${HOME}/.ssh/config" "${TARBALL}" "${REMOTE_NAME}:/tmp/"
+        ssh -F "${HOME}/.ssh/config" -t -t "${REMOTE_NAME}" \
             "sudo tar -C / --exclude=vmlinux-* -xhvf /tmp/${TARBALL}"
-        ssh -F ${HOME}/.ssh/config -t -t ${REMOTE_NAME} \
+        ssh -F "${HOME}/.ssh/config" -t -t "${REMOTE_NAME}" \
             "sudo update-initramfs -c -k ${VERSION}"
-        ssh -F ${HOME}/.ssh/config -t -t ${REMOTE_NAME} \
+        ssh -F "${HOME}/.ssh/config" -t -t "${REMOTE_NAME}" \
             "sudo update-grub"
-        ssh -F ${HOME}/.ssh/config -t -t ${REMOTE_NAME} \
+        ssh -F "${HOME}/.ssh/config" -t -t "${REMOTE_NAME}" \
             "sudo linux-update-symlinks install ${VERSION} /boot/vmlinuz-${VERSION}"
-        ssh -F ${HOME}/.ssh/config -t -t ${REMOTE_NAME} \
+        ssh -F "${HOME}/.ssh/config" -t -t "${REMOTE_NAME}" \
             "sudo reboot now"
     fi
 }
@@ -173,14 +178,15 @@ function install {
 clean
 setup
   # Need to get kernelrelease
+# shellcheck disable=SC2046
 make -j $(nproc) modules_prepare
 VERSION=$(make -s kernelrelease)
-if [ ${NO_BUILD} == "true" ]; then
+if [ "${NO_BUILD}" == "true" ]; then
     echo "INFO. User requested we stop after setup. Exiting."
     exit 0
 fi
 build
-if [ ${NO_INSTALL} == "true" ]; then
+if [ "${NO_INSTALL}" == "true" ]; then
     echo "INFO. User requested we stop before install. Exiting."
     exit 0
 fi

--- a/scripts/init-update
+++ b/scripts/init-update
@@ -29,56 +29,56 @@ remotes["amdgpu"]="https://github.com/ROCm/amdgpu.git"
 
 git_check_tag ()
 {
-    if git branch | grep stable | grep $1; then
-	echo 1
+    if git branch | grep stable | grep "$1"; then
+        echo 1
     fi
     echo 0
 }
 
 git_kernel_init ()
 {
-    cd ${KERNEL_DIR}
+    cd "${KERNEL_DIR}"
     git init
 }
 
 git_kernel_remotes ()
 {
-    cd ${KERNEL_DIR}
+    cd "${KERNEL_DIR}"
     for key in "${!remotes[@]}"; do
-	if git remote -v | grep -i $key &> /dev/null; then
-	    echo "Found remote $key"
-	else
-	    echo "Remote $key not found, adding"
-	    git remote add $key ${remotes[$key]}
-	fi
+        if git remote -v | grep -i "$key" &> /dev/null; then
+            echo "Found remote $key"
+        else
+            echo "Remote $key not found, adding"
+            git remote add "$key" "${remotes[$key]}"
+        fi
     done
 }
 
 git_kernel_update ()
 {
-    cd ${KERNEL_DIR}
-    git fetch --all -j $(nproc) --no-show-forced-updates --depth=${GIT_DEPTH}
+    cd "${KERNEL_DIR}"
+    git fetch --all -j "$(nproc)" --no-show-forced-updates --depth="${GIT_DEPTH}"
     NEWEST_STABLE_TAG=$(git tag -l 'v*' --sort 'v:refname' | grep -v rc | tail -n 1)
     echo "  INFO: Newest stable tag detected is ${NEWEST_STABLE_TAG}."
-    if [ ${CHECK_OUT} == "yes" ]; then
-        if [[ $(git_check_tag ${NEWEST_STABLE_TAG}) == "0" ]]; then
+    if [ "${CHECK_OUT}" == "yes" ]; then
+        if [[ $(git_check_tag "${NEWEST_STABLE_TAG}") == "0" ]]; then
             echo "  INFO: Checking out ${NEWEST_STABLE_TAG} locally as stable-${NEWEST_STABLE_TAG}."
-            git checkout -b stable-${NEWEST_STABLE_TAG} ${NEWEST_STABLE_TAG}
+            git checkout -b "stable-${NEWEST_STABLE_TAG}" "${NEWEST_STABLE_TAG}"
         else
             echo "  INFO: Local branch stable-${NEWEST_STABLE_TAG} already exists."
         fi
-    elif [ ${CHECK_OUT} == "no" ]; then
+    elif [ "${CHECK_OUT}" == "no" ]; then
         echo "  INFO: Newest tag is (${NEWEST_STABLE_TAG}) but skipping check out."
     else
         NOW=$(date +%s)
         echo "  INFO: Attempting to checkout remote ${CHECK_OUT} to check-out-${NOW}."
-        git checkout -b check-out-${NOW} ${CHECK_OUT}
+        git checkout -b "check-out-${NOW}" "${CHECK_OUT}"
     fi
 }
 
 if [ ! -d "${KERNEL_DIR}" ]; then
     echo "Creating kernel source in ${KERNEL_DIR}..."
-    mkdir -p ${KERNEL_DIR}
+    mkdir -p "${KERNEL_DIR}"
     git_kernel_init
 else
     echo "Kernel source folder (${KERNEL_DIR}) already exists. Updating..."


### PR DESCRIPTION
Add a shellcheck job that runs on every PR to main (no path filter), catching shell scripting bugs across all 10 bash scripts regardless of which file changed. Fix all shellcheck findings across the codebase: exit -1 → exit 1 (SC2242), unquoted variables (SC2086), fragile for-over-find loops (SC2044), bare cd without || exit (SC2164), cd/cd- replaced with subshells (SC2103), backticks replaced with $() (SC2006), and a riscv32 toolchain name typo.

Harden existing workflows: build-amdgpu-dkms-test now detects the available kernel headers version dynamically instead of using a hardcoded string, and exercises the FORCE=yes rebuild path. build-remote-test adds an explicit .config verification step per matrix leg to confirm config-script fragments were actually applied. init-update-test adds a remote-list sanity check after the first run. spell-check-test drops its path filter so it runs on every PR.

Add three new workflows: userspace-build-test (Makefile dry-run for the HIP test program on userspace/** changes), release (publishes patch tarballs and useful-configs on v* tags via softprops/action-gh-release), and dependabot config for monthly action version bump PRs.